### PR TITLE
fix: enable TLSv1.2 on Android API 16+

### DIFF
--- a/app/src/main/java/com/daskiworks/ghwatch/backend/RemoteSystemClient.java
+++ b/app/src/main/java/com/daskiworks/ghwatch/backend/RemoteSystemClient.java
@@ -45,6 +45,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.ClientContext;
+import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -60,7 +61,6 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -75,6 +75,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.zip.GZIPInputStream;
+
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Helper class used to communicate with server.
@@ -436,6 +438,8 @@ public class RemoteSystemClient {
 
   protected static DefaultHttpClient prepareHttpClient(URI uri) {
     DefaultHttpClient httpClient = new DefaultHttpClient();
+    Scheme https = new Scheme("https", new TlsSniSocketFactory(), 443);
+    httpClient.getConnectionManager().getSchemeRegistry().register(https);
     HttpParams params = httpClient.getParams();
     HttpConnectionParams.setConnectionTimeout(params, 30000);
     HttpConnectionParams.setSoTimeout(params, 30000);

--- a/app/src/main/java/com/daskiworks/ghwatch/backend/TlsSniSocketFactory.java
+++ b/app/src/main/java/com/daskiworks/ghwatch/backend/TlsSniSocketFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2010-2013 Eric Kok et al.
+ *
+ * Transdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Transdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.daskiworks.ghwatch.backend;
+
+import android.annotation.TargetApi;
+import android.net.SSLCertificateSocketFactory;
+import android.os.Build;
+import android.util.Log;
+
+import org.apache.http.conn.scheme.LayeredSocketFactory;
+import org.apache.http.conn.ssl.StrictHostnameVerifier;
+import org.apache.http.params.HttpParams;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+/**
+ * Implements an HttpClient socket factory with extensive support for SSL. Many thanks to http://blog.dev001.net/post/67082904181/android-using-sni-and-tlsv1-2-with-apache-httpclient
+ * for the base implementation.
+ * <p/>
+ * All SSL protocols that a particular Android version support will be enabled (according to http://developer.android.com/reference/javax/net/ssl/SSLSocket.html).
+ * This currently includes SSL v3 and TLSv1.0, v1.1 and v1.2.
+ * <p/>
+ * SNI is supported for host name verification. For Android 4.2+, which supports it natively, the default (strict) hostname verifier is used. For
+ * Android 4.1 and earlier it is possibly supported through reflexion on the same methods.
+ */
+public class TlsSniSocketFactory implements LayeredSocketFactory {
+
+    private final static HostnameVerifier hostnameVerifier = new StrictHostnameVerifier();
+
+    // Plain TCP/IP (layer below TLS)
+
+    @Override
+    public Socket connectSocket(Socket s, String host, int port, InetAddress localAddress, int localPort,
+                                HttpParams params) throws IOException {
+        return null;
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return null;
+    }
+
+    @Override
+    public boolean isSecure(Socket s) throws IllegalArgumentException {
+        if (s instanceof SSLSocket) {
+            return s.isConnected();
+        }
+        return false;
+    }
+
+    // TLS layer
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    public Socket createSocket(Socket plainSocket, String host, int port, boolean autoClose) throws IOException {
+        if (autoClose) {
+            // we don't need the plainSocket
+            plainSocket.close();
+        }
+
+        SSLCertificateSocketFactory sslSocketFactory =
+                (SSLCertificateSocketFactory) SSLCertificateSocketFactory.getDefault(0);
+
+        // create and connect SSL socket, but don't do hostname/certificate verification yet
+        SSLSocket ssl = (SSLSocket) sslSocketFactory.createSocket(InetAddress.getByName(host), port);
+
+        // enable TLSv1.1/1.2 if available
+        ssl.setEnabledProtocols(ssl.getSupportedProtocols());
+
+        // set up SNI before the handshake
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            sslSocketFactory.setHostname(ssl, host);
+        } else {
+            try {
+                java.lang.reflect.Method setHostnameMethod = ssl.getClass().getMethod("setHostname", String.class);
+                setHostnameMethod.invoke(ssl, host);
+            } catch (Exception e) {
+                Log.d(TlsSniSocketFactory.class.getSimpleName(), "SNI not usable: " + e);
+            }
+        }
+
+        // verify hostname and certificate
+        SSLSession session = ssl.getSession();
+        if (!hostnameVerifier.verify(host, session)) {
+            throw new SSLPeerUnverifiedException("Cannot verify hostname: " + host);
+        }
+
+        return ssl;
+    }
+
+}


### PR DESCRIPTION
i finally got it to work :-) enables TLSv1.2 by using this class: https://github.com/erickok/transdroid/blob/master/app/src/main/java/org/transdroid/daemon/util/TlsSniSocketFactory.java as a SocketFactory as suggested in https://stackoverflow.com/questions/28943660/how-to-enable-tls-1-2-support-in-an-android-application-running-on-android-4-1

I removed the insecure possibilities to accept self-signed Certificates or bypass SSL completely from the original file, since they're not needed.

fixes #108 
tested on two Android Devices running 4.2.2 Jelly Bean and 5.0.1 Lollipop.